### PR TITLE
[FIX] business_requirement_deriverable: Remove task_name field on bus…

### DIFF
--- a/business_requirement_deliverable/README.rst
+++ b/business_requirement_deliverable/README.rst
@@ -52,9 +52,10 @@ Credits
 Contributors
 ------------
 
-Eric Caudal<eric.caudal@elico-corp.com>
-Alex Duan<alex.duan@elico-corp.com>
-Xie XiaoPeng<xie.xiaopeng@elico-corp.com>
+* Eric Caudal <eric.caudal@elico-corp.com>
+* Alex Duan <alex.duan@elico-corp.com>
+* Xie XiaoPeng <xie.xiaopeng@elico-corp.com>
+* Victor M. Martin <victor.martin@elico-corp.com>
 
 Maintainer
 ----------

--- a/business_requirement_deliverable/__openerp__.py
+++ b/business_requirement_deliverable/__openerp__.py
@@ -5,7 +5,7 @@
     'name': 'Business Requirement Deliverable',
     'category': 'Business Requirements Management',
     'summary': 'Business Requirement Deliverable',
-    'version': '8.0.2.0.1',
+    'version': '8.0.3.0.1',
     'website': 'www.elico-corp.com',
     "author": "Elico Corp, Odoo Community Association (OCA)",
     'depends': [

--- a/business_requirement_deliverable/models/business.py
+++ b/business_requirement_deliverable/models/business.py
@@ -36,7 +36,6 @@ class BusinessRequirementResource(models.Model):
         string='Assign To',
         ondelete='set null'
     )
-    task_name = fields.Char('Task name')
     business_requirement_deliverable_id = fields.Many2one(
         comodel_name='business.requirement.deliverable',
         string='Business Requirement Deliverable',

--- a/business_requirement_deliverable/tests/test_br.py
+++ b/business_requirement_deliverable/tests/test_br.py
@@ -65,16 +65,14 @@ class BusinessRequirementTestCase(common.TransactionCase):
                                 'uom_id': self.uom_hours.id,
                                 'unit_price': 500,
                                 'resource_type': 'task',
-                                'task_name': 'task 1'
                             }),
                             (0, 0, {
                                 'description': 'Resource Line1',
-                                'product_id': self.productB.id,
+                                'product_id': self.productC.id,
                                 'qty': 100,
                                 'uom_id': self.uom_hours.id,
                                 'unit_price': 500,
                                 'resource_type': 'task',
-                                'task_name': 'task 2'
                             })
                         ]
                         }),
@@ -128,6 +126,7 @@ class BusinessRequirementTestCase(common.TransactionCase):
                 if resource and resource.description == 'Resource Line1':
                     res = resource.write({'product_id': self.productB.id})
                     if res:
+                        resource.product_id_change()
                         self.assertEqual(
                             resource.product_id.id, self.productB.id)
                         self.assertEqual(

--- a/business_requirement_deliverable/views/business_view.xml
+++ b/business_requirement_deliverable/views/business_view.xml
@@ -59,7 +59,6 @@
                     <field name="unit_price"/>
                     <field name="price_total"/>
                     <field name="user_id" attrs="{'readonly':[('resource_type','=','procurement')]}"/>
-                    <field name="task_name" attrs="{'readonly':[('resource_type','=','procurement')],'required':[('resource_type','=','task')]}"/>
                 </tree>
             </field>
         </record>


### PR DESCRIPTION
…iness.py, test_br.py and business_view, Fix unit test. Upgrade this module implies upgrade other modules had reference to "business.requirement.resource" (task_name field)
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/xie8899/project/pull/17%23issuecomment-189079180%22%2C%20%22https%3A//github.com/xie8899/project/pull/17%23issuecomment-189079595%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/xie8899/project/pull/17%23issuecomment-189079180%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22this%20change%20implies%20another%20one%20in%20the%20wizard%20to%20create%20project%20%28task%20name%20of%20created%20tasks%20should%20be%20the%20description%20of%20the%20resource%29.%5Cr%5CnCan%20you%20check%20it%3F%22%2C%20%22created_at%22%3A%20%222016-02-26T02%3A11%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7600613%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/elicoidal%22%7D%7D%2C%20%7B%22body%22%3A%20%22LGTM%22%2C%20%22created_at%22%3A%20%222016-02-26T02%3A13%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7600613%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/elicoidal%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/xie8899/project/pull/17#issuecomment-189079180'>General Comment</a></b>
- <a href='https://github.com/elicoidal'><img border=0 src='https://avatars.githubusercontent.com/u/7600613?v=3' height=16 width=16'></a> this change implies another one in the wizard to create project (task name of created tasks should be the description of the resource).
  Can you check it?
- <a href='https://github.com/elicoidal'><img border=0 src='https://avatars.githubusercontent.com/u/7600613?v=3' height=16 width=16'></a> LGTM

<a href='https://www.codereviewhub.com/xie8899/project/pull/17?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/xie8899/project/pull/17?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/xie8899/project/pull/17'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
